### PR TITLE
Removed instance Variable sets.

### DIFF
--- a/lib/tictactoe.rb
+++ b/lib/tictactoe.rb
@@ -1,12 +1,14 @@
 require 'game_board'
 require 'game_rules'
 require 'game_state'
+require 'player_manager'
 
 class TicTacToe
 
-  def initialize(board, rules)
+  def initialize(player_manager, board, rules)
     @rules = rules
     @board = board
+    @players = player_manager
   end
 
   def get_board
@@ -31,12 +33,21 @@ class TicTacToe
 
   def play_move(move)
     if valid_move?(move)
-      @board.play_move(move)
+      @board.play_move(@players.current_player.mark, move)
+      @players.switch_turns
     end
   end
 
   def valid_move?(move)
     @board.valid_move?(move)
+  end
+
+  def get_ai_player_move
+    @players.current_player.type.get_move(get_game_state) if is_current_player_ai?
+  end
+
+  def is_current_player_ai?
+    @players.current_player.type.respond_to?(:get_move)
   end
 
   private

--- a/lib/tictactoe.rb
+++ b/lib/tictactoe.rb
@@ -1,14 +1,12 @@
 require 'game_board'
 require 'game_rules'
 require 'game_state'
-require 'player_manager'
 
 class TicTacToe
 
-  def initialize(player1, player2)
-    @rules = GameRules.new
-    @board = GameBoard.new
-    @players = PlayerManager.new(player1, player2)
+  def initialize(board, rules)
+    @rules = rules
+    @board = board
   end
 
   def get_board
@@ -33,21 +31,12 @@ class TicTacToe
 
   def play_move(move)
     if valid_move?(move)
-      @board.play_move(@players.current_player.mark, move)
-      @players.switch_turns
+      @board.play_move(move)
     end
   end
 
   def valid_move?(move)
     @board.valid_move?(move)
-  end
-
-  def get_ai_player_move
-    @players.current_player.type.get_move(get_game_state) if is_current_player_ai?
-  end
-
-  def is_current_player_ai?
-    @players.current_player.type.respond_to?(:get_move)
   end
 
   private

--- a/spec/tictactoe_spec.rb
+++ b/spec/tictactoe_spec.rb
@@ -7,27 +7,21 @@ describe TicTacToe do
   let(:board) { double }
   let(:players) { double }
   let(:state) { double }
-  let(:ai_basic) { AiBasic.new(GameRules.new) }
-  Player = Struct.new(:mark, :type)
-  let(:test_player) { Player.new(:X, ai_basic) }
 
-  let(:test_ttt) { TicTacToe.new('HUMAN', 'HUMAN') }
+  let(:test_ttt) { TicTacToe.new(board, rules) }
 
   describe "boolean methods : game_over? tied? valid_move?" do
     it "returns false when game is not over" do
-      test_ttt.instance_variable_set("@rules", rules)
       expect(rules).to receive(:game_over?)
       test_ttt.game_over?
     end
 
     it "tied? calls rules.tied?" do
-      test_ttt.instance_variable_set("@rules", rules)
       expect(rules).to receive(:tied?)
       test_ttt.tied_game?
     end
 
     it "valid_move? calls board.valid_move?" do
-      test_ttt.instance_variable_set("@board", board)
       expect(board).to receive(:valid_move?).with(0)
       test_ttt.valid_move?(0)
     end
@@ -35,7 +29,6 @@ describe TicTacToe do
 
   describe "Getting the winner" do
     it "winner calls rules.winner(@board)" do
-      test_ttt.instance_variable_set("@rules", rules)
       expect(rules).to receive(:winner)
       test_ttt.winner
     end
@@ -44,7 +37,6 @@ describe TicTacToe do
 
   describe "Getting the game_board" do
     it "get_board calls @board.spaces" do
-      test_ttt.instance_variable_set("@board", board)
       expect(board).to receive(:spaces)
       test_ttt.get_board
     end
@@ -52,44 +44,16 @@ describe TicTacToe do
 
   describe "Playing a Human move" do
     it "if move is valid @board.spaces and @player.switch_turns are called" do
-      test_ttt.instance_variable_set("@players", players)
-      test_ttt.instance_variable_set("@board", board)
       expect(board).to receive(:valid_move?).with(0).and_return(true)
       expect(board).to receive(:play_move)
-      allow(players).to receive(:current_player).and_return(test_player)
-      expect(players).to receive(:switch_turns)
       test_ttt.play_move(0)
     end
 
     it "if move is not valid @board.spaces and @player.switch_turns are NOT called" do
-      test_ttt.instance_variable_set("@board", board)
-      test_ttt.instance_variable_set("@players", players)
       expect(board).to receive(:valid_move?).with(0).and_return(false)
       expect(board).to receive(:spaces).exactly(0).times
       expect(players).to receive(:switch_turns).exactly(0).times
       test_ttt.play_move(0)
-    end
-  end
-
-  describe "Getting an Ai move" do
-    it "current_player is an Ai it calls get_move" do
-      test_ttt.instance_variable_set("@players", players)
-      expect(test_ttt).to receive(:get_game_state)
-      expect(test_ttt).to receive(:is_current_player_ai?).and_return(true)
-      expect(players).to receive(:current_player).and_return(test_player)
-      expect(test_player).to receive(:type).and_return(ai_basic)
-      expect(ai_basic).to receive(:get_move)
-      test_ttt.get_ai_player_move
-    end
-
-    it "current_player is NOT Ai it doesn't call get_move" do
-      test_ttt.instance_variable_set("@players", players)
-      expect(test_ttt).to receive(:is_current_player_ai?).and_return(false)
-      expect(test_ttt).to receive(:get_game_state).exactly(0).times
-      expect(players).to receive(:current_player).and_return(test_player).exactly(0).times
-      expect(test_player).to receive(:type).and_return(ai_basic).exactly(0).times
-      expect(ai_basic).to receive(:get_move).exactly(0).times
-      test_ttt.get_ai_player_move
     end
   end
 end

--- a/spec/tictactoe_spec.rb
+++ b/spec/tictactoe_spec.rb
@@ -7,8 +7,10 @@ describe TicTacToe do
   let(:board) { double }
   let(:players) { double }
   let(:state) { double }
-
-  let(:test_ttt) { TicTacToe.new(board, rules) }
+  let(:ai_basic) { AiBasic.new(GameRules.new) }
+  Player = Struct.new(:mark, :type)
+  let(:test_player) { Player.new(:X, ai_basic) }
+  let(:test_ttt) { TicTacToe.new(players, board, rules) }
 
   describe "boolean methods : game_over? tied? valid_move?" do
     it "returns false when game is not over" do
@@ -46,6 +48,8 @@ describe TicTacToe do
     it "if move is valid @board.spaces and @player.switch_turns are called" do
       expect(board).to receive(:valid_move?).with(0).and_return(true)
       expect(board).to receive(:play_move)
+      allow(players).to receive(:current_player).and_return(test_player)
+      expect(players).to receive(:switch_turns)
       test_ttt.play_move(0)
     end
 
@@ -54,6 +58,26 @@ describe TicTacToe do
       expect(board).to receive(:spaces).exactly(0).times
       expect(players).to receive(:switch_turns).exactly(0).times
       test_ttt.play_move(0)
+    end
+  end
+
+  describe "Getting an Ai move" do
+    it "current_player is an Ai it calls get_move" do
+      expect(test_ttt).to receive(:get_game_state)
+      expect(test_ttt).to receive(:is_current_player_ai?).and_return(true)
+      expect(players).to receive(:current_player).and_return(test_player)
+      expect(test_player).to receive(:type).and_return(ai_basic)
+      expect(ai_basic).to receive(:get_move)
+      test_ttt.get_ai_player_move
+    end
+
+    it "current_player is NOT Ai it doesn't call get_move" do
+      expect(test_ttt).to receive(:is_current_player_ai?).and_return(false)
+      expect(test_ttt).to receive(:get_game_state).exactly(0).times
+      expect(players).to receive(:current_player).and_return(test_player).exactly(0).times
+      expect(test_player).to receive(:type).and_return(ai_basic).exactly(0).times
+      expect(ai_basic).to receive(:get_move).exactly(0).times
+      test_ttt.get_ai_player_move
     end
   end
 end


### PR DESCRIPTION
Removed instance variable setting from tests. TerminalTicTacToe now receives the classes it need in constructor. This was done so that mocks could be used instead.
