### PR TITLE
GameBoard now has a method for getting corners.

### DIFF
--- a/lib/ai_basic.rb
+++ b/lib/ai_basic.rb
@@ -25,19 +25,11 @@ private
   end
 
   def get_corner(board, available_moves)
-    available_corners =  corners(board.grid_size) & available_moves
+    available_corners =  board.corners & available_moves
     if available_corners.size > 0
       index = rand(0...available_corners.size)
       available_corners[index]
     end
-  end
-
-  def corners(grid_size)
-    rtn_corners = [0]
-    rtn_corners << grid_size - 1
-    rtn_corners << (grid_size * grid_size) - grid_size
-    rtn_corners << (grid_size * grid_size) - 1
-    rtn_corners
   end
 
   def play_to_block(board, available_moves)

--- a/lib/ai_minimax.rb
+++ b/lib/ai_minimax.rb
@@ -1,7 +1,5 @@
 class AiMinimax
 
-  CORNERS = [0,2,6,8]
-  OPPOSITE_CORNERS = [8,6,2,0]
   def initialize(board_rules)
     @rules = board_rules
   end
@@ -29,12 +27,12 @@ class AiMinimax
   end
 
   def corner_move(board)
-    available_corners = CORNERS & board.available_moves
+    available_corners = board.corners & board.available_moves
     available_corners.sample
   end
 
   def opponent_played_corner_for_first_move?(board)
-    CORNERS.any? { |corner| board.spaces[corner] != ' '} if (board.available_moves.size == 8)
+    board.corners.any? { |corner| board.spaces[corner] != ' '} if (board.available_moves.size == 8)
   end
 
   def best_move(board, player, opponent)

--- a/lib/game_board.rb
+++ b/lib/game_board.rb
@@ -16,6 +16,15 @@ class GameBoard
     temp_board
   end
 
+  def corners
+    rtn_corners = [0]
+    rtn_corners << grid_size - 1
+    rtn_corners << (grid_size * grid_size) - grid_size
+    rtn_corners << (grid_size * grid_size) - 1
+    rtn_corners
+  end
+
+
   def valid_move?(space)
     @spaces[space] == ' '
   end

--- a/spec/game_board_spec.rb
+++ b/spec/game_board_spec.rb
@@ -2,12 +2,23 @@ require 'game_board'
 
 describe GameBoard do
   let(:test_board) { GameBoard.new(3) }
+  let(:test_board_4x4) { GameBoard.new(4) }
 
   describe "deep copy " do
     it "makes a deep copy " do
       test_board_2 = test_board.deep_copy
       test_board.spaces[1] = 'X'
       expect(test_board_2.spaces[1]).to eq(' ')
+    end
+  end
+
+  describe "getting corners" do
+    it "returns 0 2 6 8 for a 3x3 board" do
+      expect(test_board.corners).to eq([0, 2, 6, 8])
+    end
+
+    it "reutrns 0 3 12 15 for a 4x4 board" do
+      expect(test_board_4x4.corners).to eq([0, 3, 12, 15])
     end
   end
 


### PR DESCRIPTION
Originally when I went to remove knowledge of the corners, I had the ai_basic ask for the grid_size of the board and calculate the corners. I moved that logic into the game_board class where it belongs. Then changed the ai_basic and ai_minimax to call the corners method from the GameBoard class.
